### PR TITLE
adds getTotalFolderCount()

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -43,6 +43,7 @@ stop	KEYWORD2
 getStatus	KEYWORD2
 getFolderTrackCount	KEYWORD2
 getTotalTrackCount	KEYWORD2
+getTotalFolderCount	KEYWORD2
 playAdvertisement	KEYWORD2
 stopAdvertisement	KEYWORD2							
 

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -251,6 +251,12 @@ public:
         return listenForReply(0x48);
     }
 
+    uint16_t getTotalFolderCount()
+    {
+        sendPacket(0x4F);
+        return listenForReply(0x4F);
+    }
+
     // sd:/advert/####track name
     void playAdvertisement(uint16_t track)
     {


### PR DESCRIPTION
Hi,

this is a quite simple addition which adds a **getTotalFolderCount()** function, which returns the total number of folders on the current storage device. Usefull if you want to iterate over the available folders (ie. to play the first track in each folder) and stop at the last folder.

cheers
Stephan
