### PR TITLE
raises serial timeout in DFPlayer Mini communication

### DIFF
--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -81,7 +81,7 @@ public:
     void begin()
     {
         _serial.begin(9600);
-        _serial.setTimeout(4200);
+        _serial.setTimeout(10000);
         _lastSend = millis();
     }
 

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -81,7 +81,7 @@ public:
     void begin()
     {
         _serial.begin(9600);
-        _serial.setTimeout(600);
+        _serial.setTimeout(4200);
         _lastSend = millis();
     }
 


### PR DESCRIPTION
Hi @Makuna,

during usage of your awesome library I discovered that the timeout of 600ms, which is in place in the serial communication to the DFPlayer Mini module, is not sufficient when you have many folders with files on the SD card.

Here is why: According to the data sheet you can have 99 folders with up to 255 files each (plus files in the mp3 and advert folder), maxing out at 25.245+ files. Due to the way the DFPlayer Mini module organizes the access to these files, folders that are copied later in sequence to the SD card take longer to access. Way longer than the original timeout of 600ms set on the serial link allows. This results in your library throwing the `general error 255` exception, thus making certain functions unusable and folders inaccessible.

Example: If you have say 10 folders (01-10) with 255 files each this happens at about folder 7 or 8.

The below output is

`folder: files_in_folder --> ms how long it took the module to reply to getFolderTrackCount()`:

```
total tracks: 25245

1: 255 --> 133
2: 255 --> 210
3: 255 --> 289
4: 255 --> 366
5: 255 --> 442
6: 255 --> 520
7: 255 --> 598
8: 255 --> 675
9: 255 --> 752
10: 255 --> 824
```

As you can see accessing folder 7 barely fits into the 600ms, folder 8 would fail (the above output is with increased timeout of 4200ms in place already). When reaching folder 45 it already looks like this:

```
44: 255 --> 3438
45: 255 --> 3518
46: 255 --> 3594
```

And in the end for folder 99:

```
97: 255 --> 7585
98: 255 --> 7661
99: 255 --> 7740
```

Hence I propose to increase the serial timeout to lets say 10000ms to be able to use all 99 folders with the theoretical maximum of 255 files each. Please advise.

EDIT: I dunno how I came up with 4200... was very late yesterday when we discovered this. ;) Correct values edited in above text and pull request updated. Sorry for the confusion.

cheers
Stephan