### PR TITLE
adds functions to enable/disable the dac

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -45,7 +45,9 @@ getFolderTrackCount	KEYWORD2
 getTotalTrackCount	KEYWORD2
 getTotalFolderCount	KEYWORD2
 playAdvertisement	KEYWORD2
-stopAdvertisement	KEYWORD2							
+stopAdvertisement	KEYWORD2
+enableDac	KEYWORD2
+disableDac	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -282,6 +282,16 @@ public:
         sendPacket(0x15);
     }
 
+    void enableDac()
+    {
+        sendPacket(0x1A, 0x00);
+    }
+
+    void disableDac()
+    {
+        sendPacket(0x1A, 0x01);
+    }
+
 private:
     static const uint16_t c_msSendSpace = 50;
 


### PR DESCRIPTION
Hi @Makuna,

legit chips like Flyron YX5200 support these as per the data sheet. I have confirmed functionality with some derivates as well, but not all. Never the less its a useful feature in certain scenarios and does not hurt regular operation if the chip does not support it. In my tests it was just ignored in that case.