### PR TITLE
Add support for DFPlayer modules using a MH2024K-16SS chip

### DIFF
--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -537,6 +537,7 @@ private:
                     switch (replyCommand)
                     {
                     case 0x3c: // usb
+                    case 0x4b: // usb on MH2024K-16SS
                         T_NOTIFICATION_METHOD::OnPlayFinished(*this, DfMp3_PlaySources_Usb, replyArg);
                         break;
 

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -594,8 +594,11 @@ private:
 
     uint16_t calcChecksum(DfMp3_Packet& packet)
     {
-        uint16_t sum = packet.version + packet.length + packet.command + packet.requestAck + packet.hiByteArgument + packet.lowByteArgument;
-        return -sum;
+        uint16_t sum = 0xFFFF;
+        for (uint8_t* i = &packet.version; i != &packet.hiByteCheckSum; i++) {
+            sum -= *i;
+        }
+        return sum + 1;
     }
 
     void setChecksum(DfMp3_Packet* out)

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -114,7 +114,7 @@ struct DfMp3_Packet_WithoutCheckSum
 
 class Mp3ChipMH2024K16SS {
 public:
-    static const bool mustSendChecksum = false;
+    static const bool SendCheckSum = false;
 
     typedef DfMp3_Packet_WithoutCheckSum SendPacket;
     typedef DfMp3_Packet_WithCheckSum ReceptionPacket;
@@ -122,7 +122,7 @@ public:
 
 class Mp3ChipOriginal {
 public:
-    static const bool mustSendChecksum = true;
+    static const bool SendCheckSum = true;
 
     typedef DfMp3_Packet_WithCheckSum SendPacket;
     typedef DfMp3_Packet_WithCheckSum ReceptionPacket;
@@ -431,7 +431,7 @@ private:
     void sendPacket(uint8_t command, uint16_t arg = 0, uint16_t sendSpaceNeeded = c_msSendSpace)
     {
         typename T_CHIP_VARIANT::SendPacket packet;
-        if (T_CHIP_VARIANT::mustSendChecksum)
+        if (T_CHIP_VARIANT::SendCheckSum)
         {
             packet = {
                 0x7E,

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -82,10 +82,11 @@ template <class T_SERIAL_METHOD, class T_NOTIFICATION_METHOD>
 class DFMiniMp3
 {
 public:
-    explicit DFMiniMp3(T_SERIAL_METHOD &serial, boolean sendChecksum = true) : _serial(serial),
-                                                                               _lastSendSpace(c_msSendSpace),
-                                                                               _isOnline(false),
-                                                                               _sendChecksum(sendChecksum)
+    explicit DFMiniMp3(T_SERIAL_METHOD& serial, boolean sendChecksum = true) :
+        _serial(serial),
+        _lastSendSpace(c_msSendSpace),
+        _isOnline(false),
+        _sendChecksum(sendChecksum)
     {
     }
 
@@ -399,7 +400,7 @@ private:
         uint8_t endCode;
     };
 
-    T_SERIAL_METHOD &_serial;
+    T_SERIAL_METHOD& _serial;
     uint32_t _lastSend; // not initialized as agreed in issue #63
     uint16_t _lastSendSpace;
     bool _isOnline;
@@ -415,7 +416,7 @@ private:
 
     void sendPacket(uint8_t command, uint16_t arg = 0, uint16_t sendSpaceNeeded = c_msSendSpace)
     {
-        const uint8_t *out;
+        const uint8_t* out;
         size_t len;
         if (_sendChecksum)
         {
@@ -429,9 +430,9 @@ private:
                 static_cast<uint8_t>(arg & 0x00ff),
                 0,
                 0,
-                0xEF};
+                0xEF };
             setChecksum(packet);
-            out = (const uint8_t *)&packet;
+            out = (const uint8_t*)&packet;
             len = sizeof(packet);
         }
         else
@@ -444,8 +445,8 @@ private:
                 0,
                 static_cast<uint8_t>(arg >> 8),
                 static_cast<uint8_t>(arg & 0x00ff),
-                0xEF};
-            out = (const uint8_t *)&packet;
+                0xEF };
+            out = (const uint8_t*)&packet;
             len = sizeof(packet);
         }
 
@@ -464,9 +465,9 @@ private:
         _lastSend = millis();
     }
 
-    bool readPacket(uint8_t *command, uint16_t *argument)
+    bool readPacket(uint8_t* command, uint16_t* argument)
     {
-        DfMp3_Packet in = {0};
+        DfMp3_Packet in = { 0 };
         uint8_t read;
 
         // init our out args always
@@ -590,13 +591,13 @@ private:
         return 0;
     }
 
-    uint16_t calcChecksum(DfMp3_Packet &packet)
+    uint16_t calcChecksum(DfMp3_Packet& packet)
     {
         uint16_t sum = packet.version + packet.length + packet.command + packet.requestAck + packet.hiByteArgument + packet.lowByteArgument;
         return -sum;
     }
 
-    void setChecksum(DfMp3_Packet &out)
+    void setChecksum(DfMp3_Packet& out)
     {
         uint16_t sum = calcChecksum(out);
 
@@ -604,7 +605,7 @@ private:
         out.lowByteCheckSum = (sum & 0xff);
     }
 
-    bool validateChecksum(DfMp3_Packet &in)
+    bool validateChecksum(DfMp3_Packet& in)
     {
         uint16_t sum = calcChecksum(in);
         return (sum == static_cast<uint16_t>((in.hiByteCheckSum << 8) | in.lowByteCheckSum));

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -478,7 +478,7 @@ private:
 
     bool readPacket(uint8_t* command, uint16_t* argument)
     {
-        DfMp3_Packet_WithCheckSum in = { 0 };
+        DfMp3_Packet_WithCheckSum in;
         uint8_t read;
 
         // init our out args always

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -43,7 +43,6 @@ enum DfMp3_Error
     DfMp3_Error_General = 0xff
 };
 
-
 enum DfMp3_PlaybackMode
 {
     DfMp3_PlaybackMode_Repeat,
@@ -51,7 +50,6 @@ enum DfMp3_PlaybackMode
     DfMp3_PlaybackMode_SingleRepeat,
     DfMp3_PlaybackMode_Random
 };
-
 
 enum DfMp3_Eq
 {
@@ -76,18 +74,17 @@ enum DfMp3_PlaySources // bitfield - more than one can be set
 {
     DfMp3_PlaySources_Usb = 0x01,
     DfMp3_PlaySources_Sd = 0x02,
-    DfMp3_PlaySources_Pc = 0x04, 
+    DfMp3_PlaySources_Pc = 0x04,
     DfMp3_PlaySources_Flash = 0x08,
 };
 
-
-template<class T_SERIAL_METHOD, class T_NOTIFICATION_METHOD> class DFMiniMp3
+template <class T_SERIAL_METHOD, class T_NOTIFICATION_METHOD>
+class DFMiniMp3
 {
 public:
-    explicit DFMiniMp3(T_SERIAL_METHOD& serial) :
-        _serial(serial),
-        _lastSendSpace(c_msSendSpace),
-        _isOnline(false)
+    explicit DFMiniMp3(T_SERIAL_METHOD &serial) : _serial(serial),
+                                                  _lastSendSpace(c_msSendSpace),
+                                                  _isOnline(false)
     {
     }
 
@@ -260,7 +257,6 @@ public:
         return static_cast<DfMp3_Eq>(listenForReply(0x44));
     }
 
-
     void setPlaybackSource(DfMp3_PlaySource source)
     {
         sendPacket(0x09, source, 200);
@@ -392,8 +388,7 @@ private:
         DfMp3_Packet_SIZE
     };
 
-
-    T_SERIAL_METHOD& _serial;
+    T_SERIAL_METHOD &_serial;
     uint32_t _lastSend; // not initialized as agreed in issue #63
     uint16_t _lastSendSpace;
     bool _isOnline;
@@ -408,16 +403,16 @@ private:
 
     void sendPacket(uint8_t command, uint16_t arg = 0, uint16_t sendSpaceNeeded = c_msSendSpace)
     {
-        uint8_t out[DfMp3_Packet_SIZE] = { 0x7E,
-            0xFF,
-            06,
-            command,
-            00,
-            static_cast<uint8_t>(arg >> 8),
-            static_cast<uint8_t>(arg & 0x00ff),
-            00,
-            00,
-            0xEF };
+        uint8_t out[DfMp3_Packet_SIZE] = {0x7E,
+                                          0xFF,
+                                          06,
+                                          command,
+                                          00,
+                                          static_cast<uint8_t>(arg >> 8),
+                                          static_cast<uint8_t>(arg & 0x00ff),
+                                          00,
+                                          00,
+                                          0xEF};
 
         setChecksum(out);
 
@@ -436,9 +431,9 @@ private:
         _lastSend = millis();
     }
 
-    bool readPacket(uint8_t* command, uint16_t* argument)
+    bool readPacket(uint8_t *command, uint16_t *argument)
     {
-        uint8_t in[DfMp3_Packet_SIZE] = { 0 };
+        uint8_t in[DfMp3_Packet_SIZE] = {0};
         uint8_t read;
 
         // init our out args always
@@ -561,7 +556,7 @@ private:
         return 0;
     }
 
-    uint16_t calcChecksum(uint8_t* packet)
+    uint16_t calcChecksum(uint8_t *packet)
     {
         uint16_t sum = 0;
         for (int i = DfMp3_Packet_Version; i < DfMp3_Packet_HiByteCheckSum; i++)
@@ -571,7 +566,7 @@ private:
         return -sum;
     }
 
-    void setChecksum(uint8_t* out)
+    void setChecksum(uint8_t *out)
     {
         uint16_t sum = calcChecksum(out);
 
@@ -579,7 +574,7 @@ private:
         out[DfMp3_Packet_LowByteCheckSum] = (sum & 0xff);
     }
 
-    bool validateChecksum(uint8_t* in)
+    bool validateChecksum(uint8_t *in)
     {
         uint16_t sum = calcChecksum(in);
         return (sum == static_cast<uint16_t>((in[DfMp3_Packet_HiByteCheckSum] << 8) | in[DfMp3_Packet_LowByteCheckSum]));

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -99,7 +99,7 @@ public:
 
     void loop()
     {
-        while (_serial.available() >= (int)sizeof(DfMp3_Packet))
+        while (_serial.available() >= static_cast<int>(sizeof(DfMp3_Packet)))
         {
             listenForReply(0x00);
         }
@@ -432,7 +432,7 @@ private:
                 0,
                 0xEF };
             setChecksum(packet);
-            out = (const uint8_t*)&packet;
+            out = reinterpret_cast<const uint8_t*>(&packet);
             len = sizeof(packet);
         }
         else
@@ -446,7 +446,7 @@ private:
                 static_cast<uint8_t>(arg >> 8),
                 static_cast<uint8_t>(arg & 0x00ff),
                 0xEF };
-            out = (const uint8_t*)&packet;
+            out = reinterpret_cast<const uint8_t*>(&packet);
             len = sizeof(packet);
         }
 

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -431,7 +431,7 @@ private:
                 0,
                 0,
                 0xEF };
-            setChecksum(packet);
+            setChecksum(&packet);
             out = reinterpret_cast<const uint8_t*>(&packet);
             len = sizeof(packet);
         }
@@ -598,12 +598,12 @@ private:
         return -sum;
     }
 
-    void setChecksum(DfMp3_Packet& out)
+    void setChecksum(DfMp3_Packet* out)
     {
-        uint16_t sum = calcChecksum(out);
+        uint16_t sum = calcChecksum(*out);
 
-        out.hiByteCheckSum = (sum >> 8);
-        out.lowByteCheckSum = (sum & 0xff);
+        out->hiByteCheckSum = (sum >> 8);
+        out->lowByteCheckSum = (sum & 0xff);
     }
 
     bool validateChecksum(DfMp3_Packet& in)

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -540,6 +540,7 @@ private:
                         break;
 
                     case 0x3d: // micro sd
+                    case 0x4c: // micro sd on MH2024K-16SS
                         T_NOTIFICATION_METHOD::OnPlayFinished(*this, DfMp3_PlaySources_Sd, replyArg);
                         break;
 

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -604,8 +604,8 @@ private:
     uint16_t calcChecksum(DfMp3_Packet_WithCheckSum& packet)
     {
         uint16_t sum = 0xFFFF;
-        for (uint8_t* i = &packet.version; i != &packet.hiByteCheckSum; i++) {
-            sum -= *i;
+        for (uint8_t* packetByte = &(packet.version); packetByte != &(packet.hiByteCheckSum); packetByte++) {
+            sum -= *packetByte;
         }
         return sum + 1;
     }

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -132,7 +132,7 @@ template <class T_SERIAL_METHOD, class T_NOTIFICATION_METHOD, class T_CHIP_VARIA
 class DFMiniMp3
 {
 public:
-    explicit DFMiniMp3(T_SERIAL_METHOD& serial, boolean sendChecksum = true) :
+    explicit DFMiniMp3(T_SERIAL_METHOD& serial) :
         _serial(serial),
         _lastSendSpace(c_msSendSpace),
         _isOnline(false)
@@ -601,10 +601,10 @@ private:
         return 0;
     }
 
-    uint16_t calcChecksum(DfMp3_Packet_WithCheckSum& packet)
+    uint16_t calcChecksum(const DfMp3_Packet_WithCheckSum& packet)
     {
         uint16_t sum = 0xFFFF;
-        for (uint8_t* packetByte = &(packet.version); packetByte != &(packet.hiByteCheckSum); packetByte++) {
+        for (const uint8_t* packetByte = &(packet.version); packetByte != &(packet.hiByteCheckSum); packetByte++) {
             sum -= *packetByte;
         }
         return sum + 1;

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -130,7 +130,7 @@ void setChecksum(DfMp3_Packet_WithCheckSum* out)
     out->lowByteCheckSum = (sum & 0xff);
 }
 
-bool validateChecksum(DfMp3_Packet_WithCheckSum& in)
+bool validateChecksum(const DfMp3_Packet_WithCheckSum& in)
 {
     uint16_t sum = calcChecksum(in);
     return (sum == static_cast<uint16_t>((in.hiByteCheckSum << 8) | in.lowByteCheckSum));


### PR DESCRIPTION
This PR adds support of DFPlayer modules that use a MH2024K-16SS chip. The main difference is that the packet sent to the module **must not** contain the checksum. The command code emitted when a song finishes is also different.

A new flag can be passed to the constructor `sendChecksum` which defaults to `true` and must be set to `false` for the MH2024K-16SS.

This MR also refactors the packet: instead of an enum, it's now a struct. However, that change wasn't mandatory for the support of this new chip.

The original idea to remove the checksum comes from this branch: https://github.com/bkk87/DFMiniMp3/blob/1.0.7-noChecksums-fixcase/src/DFMiniMp3.h (cc @bkk87)

I don't have another DFPlayer module with another chip to test.
