### PR TITLE
Automatically retry to send a command when an expected result isn't received

### DIFF
--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -191,10 +191,10 @@ public:
     {
     }
 
-    void begin(unsigned long baud = 9600)
+    void begin(unsigned long baud = 9600, unsigned long timeout = 10000)
     {
         _serial.begin(baud);
-        _serial.setTimeout(10000);
+        _serial.setTimeout(timeout);
         _lastSend = millis();
     }
 


### PR DESCRIPTION
This PR improves the reliability of the library by sending a command up to 3 times if an expected result isn't received.

On my DFPlayer module, I've encountered this problem when I receive an event (eg. SD card online) at the exact same time than I query the volume. This is probably a bug in the module itself (the volume is never received).

I also provide a way to reduce the timeout: 10s seems really long, I wanted to test with 2s instead and I thought it could be interesting to let the user decide.