### PR TITLE
Resolved the problem of multimle definition

### DIFF
--- a/src/DFMiniMp3.cpp
+++ b/src/DFMiniMp3.cpp
@@ -1,0 +1,48 @@
+/*-------------------------------------------------------------------------
+DFMiniMp3 library
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/DFMiniMp3)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/DFMiniMp3 library.
+
+DFMiniMp3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+DFMiniMp3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with DFMiniMp3.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+#pragma once
+
+#include "DFMiniMp3.h"
+
+uint16_t calcChecksum(const DfMp3_Packet_WithCheckSum& packet) {
+    uint16_t sum = 0xFFFF;
+    for (const uint8_t* packetByte = &(packet.version); packetByte != &(packet.hiByteCheckSum); packetByte++) {
+        sum -= *packetByte;
+    }
+    return sum + 1;
+}
+
+void setChecksum(DfMp3_Packet_WithCheckSum* out) {
+    uint16_t sum = calcChecksum(*out);
+
+    out->hiByteCheckSum = (sum >> 8);
+    out->lowByteCheckSum = (sum & 0xff);
+}
+
+bool validateChecksum(const DfMp3_Packet_WithCheckSum& in) {
+    uint16_t sum = calcChecksum(in);
+    return (sum == static_cast<uint16_t>((in.hiByteCheckSum << 8) | in.lowByteCheckSum));
+}

--- a/src/DFMiniMp3.cpp
+++ b/src/DFMiniMp3.cpp
@@ -27,22 +27,30 @@ License along with DFMiniMp3.  If not, see
 
 #include "DFMiniMp3.h"
 
-uint16_t calcChecksum(const DfMp3_Packet_WithCheckSum& packet) {
+uint16_t calcChecksum(const DfMp3_Packet_WithCheckSum& packet)
+{
     uint16_t sum = 0xFFFF;
-    for (const uint8_t* packetByte = &(packet.version); packetByte != &(packet.hiByteCheckSum); packetByte++) {
+    for (
+        const uint8_t* packetByte = &(packet.version);
+        packetByte != &(packet.hiByteCheckSum);
+        packetByte++
+    )
+    {
         sum -= *packetByte;
     }
     return sum + 1;
 }
 
-void setChecksum(DfMp3_Packet_WithCheckSum* out) {
+void setChecksum(DfMp3_Packet_WithCheckSum* out)
+{
     uint16_t sum = calcChecksum(*out);
 
     out->hiByteCheckSum = (sum >> 8);
     out->lowByteCheckSum = (sum & 0xff);
 }
 
-bool validateChecksum(const DfMp3_Packet_WithCheckSum& in) {
+bool validateChecksum(const DfMp3_Packet_WithCheckSum& in)
+{
     uint16_t sum = calcChecksum(in);
     return (sum == static_cast<uint16_t>((in.hiByteCheckSum << 8) | in.lowByteCheckSum));
 }

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -25,6 +25,8 @@ License along with DFMiniMp3.  If not, see
 -------------------------------------------------------------------------*/
 #pragma once
 
+#include <stdint.h>
+
 enum DfMp3_Error
 {
     // from device
@@ -112,29 +114,9 @@ struct DfMp3_Packet_WithoutCheckSum
     uint8_t endCode;
 };
 
-
-uint16_t calcChecksum(const DfMp3_Packet_WithCheckSum& packet)
-{
-    uint16_t sum = 0xFFFF;
-    for (const uint8_t* packetByte = &(packet.version); packetByte != &(packet.hiByteCheckSum); packetByte++) {
-        sum -= *packetByte;
-    }
-    return sum + 1;
-}
-
-void setChecksum(DfMp3_Packet_WithCheckSum* out)
-{
-    uint16_t sum = calcChecksum(*out);
-
-    out->hiByteCheckSum = (sum >> 8);
-    out->lowByteCheckSum = (sum & 0xff);
-}
-
-bool validateChecksum(const DfMp3_Packet_WithCheckSum& in)
-{
-    uint16_t sum = calcChecksum(in);
-    return (sum == static_cast<uint16_t>((in.hiByteCheckSum << 8) | in.lowByteCheckSum));
-}
+extern "C++" uint16_t calcChecksum(const DfMp3_Packet_WithCheckSum& packet);
+extern "C++" void setChecksum(DfMp3_Packet_WithCheckSum* out);
+extern "C++" bool validateChecksum(const DfMp3_Packet_WithCheckSum& in);
 
 class Mp3ChipMH2024K16SS {
 public:


### PR DESCRIPTION
It was leading to 

> (.text+0x0)*: multiple definition of calcChecksum(DfMp3_Packet_WithCheckSum const&)

when you try to include the library into many files explicitly or by chain.