### PR TITLE
Fix python error at PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -9,10 +9,6 @@
   },
   "version": "1.1.1",
   "frameworks": "arduino",
-  "platforms": "*",
-  "dependencies": [
-    {
-    }
-  ]
+  "platforms": "*"
 }
 


### PR DESCRIPTION
Hi Michael!

Quite nice lib!
Like to use it for another project as your lib has much better support for the (quirky) DFPlayer clones, as well as your new debugging switch!

But I/we use PlatformIO and since your newest 1.1.1 version, you've integrated library.json which throws:

```Error: Traceback (most recent call last):
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/__main__.py", line 102, in main
    cli()  # pylint: disable=no-value-for-parameter
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/cli.py", line 71, in invoke
    return super().invoke(ctx)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/project/commands/init.py", line 94, in project_init_cmd
    install_project_dependencies(
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/commands/install.py", line 106, in install_project_dependencies
    already_up_to_date = not install_project_env_dependencies(env, options)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/commands/install.py", line 132, in install_project_env_dependencies
    _install_project_env_libraries(project_env, options),
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/commands/install.py", line 247, in _install_project_env_libraries
    env_lm.install(
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/manager/_install.py", line 48, in install
    pkg = self._install(spec, skip_dependencies=skip_dependencies, force=force)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/manager/_install.py", line 92, in _install
    self.install_dependencies(pkg, print_header=False)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/manager/_install.py", line 140, in install_dependencies
    self.install_dependency(dependency)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/manager/library.py", line 91, in install_dependency
    return super().install_dependency(dependency)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/manager/_install.py", line 164, in install_dependency
    return self._install(
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/manager/_install.py", line 100, in _install
    pkg = self.install_from_registry(
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/manager/_registry.py", line 34, in install_from_registry
    packages = self.search_registry_packages(spec, search_qualifiers)
  File "/home/jebeling/.platformio/penv/lib/python3.9/site-packages/platformio/package/manager/_registry.py", line 81, in search_registry_packages
    qualifiers["names"] = spec.name.lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```

which happen due to the empty dependency object.

In PlatformIO dependencies are optional, thus I dropped them and now it compiles fine.

**BUT** I haven't tested it with Arduino IDE!
