### PR TITLE
Ack cleanup

### DIFF
--- a/examples/PlayAdvertisements/PlayAdvertisements.ino
+++ b/examples/PlayAdvertisements/PlayAdvertisements.ino
@@ -85,6 +85,13 @@ void setup()
   Serial.println("initializing...");
   
   dfmp3.begin();
+  // for boards that support hardware arbitrary pins
+  // dfmp3.begin(10, 11); // RX, TX
+
+  uint16_t version = dfmp3.getSoftwareVersion();
+  Serial.print("version ");
+  Serial.println(version);
+
   uint16_t volume = dfmp3.getVolume();
   Serial.print("volume was ");
   Serial.println(volume);

--- a/examples/PlayMp3/PlayMp3.ino
+++ b/examples/PlayMp3/PlayMp3.ino
@@ -92,6 +92,12 @@ void setup()
   Serial.println("initializing...");
   
   dfmp3.begin();
+  // for boards that support hardware arbitrary pins
+  // dfmp3.begin(10, 11); // RX, TX
+
+  uint16_t version = dfmp3.getSoftwareVersion();
+  Serial.print("version ");
+  Serial.println(version);
 
   uint16_t volume = dfmp3.getVolume();
   Serial.print("volume ");

--- a/examples/PlayRandom/PlayRandom.ino
+++ b/examples/PlayRandom/PlayRandom.ino
@@ -78,8 +78,15 @@ void setup()
   Serial.println("initializing...");
   
   dfmp3.begin();
+  // for boards that support hardware arbitrary pins
+  // dfmp3.begin(10, 11); // RX, TX
+
   dfmp3.reset(); 
   
+  uint16_t version = dfmp3.getSoftwareVersion();
+  Serial.print("version ");
+  Serial.println(version);
+
   // show some properties and set the volume
   uint16_t volume = dfmp3.getVolume();
   Serial.print("volume ");

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -25,254 +25,12 @@ License along with DFMiniMp3.  If not, see
 -------------------------------------------------------------------------*/
 #pragma once
 
-enum DfMp3_Commands
-{
-    DfMp3_Commands_None = 0x00,
-    DfMp3_Commands_PlayNextTrack = 0x01,
-    DfMp3_Commands_PlayPrevTrack = 0x02,
-    DfMp3_Commands_PlayGlobalTrack = 0x03,
-    DfMp3_Commands_IncVolume = 0x04,
-    DfMp3_Commands_DecVolume = 0x05,
-    DfMp3_Commands_SetVolume = 0x06,
-    DfMp3_Commands_SetEq = 0x07,
-    DfMp3_Commands_LoopGlobalTrack = 0x08,
-    DfMp3_Commands_SetPlaybackMode = 0x08,
-    DfMp3_Commands_SetPlaybackSource = 0x09,
-    DfMp3_Commands_Sleep = 0x0a,
-    DfMp3_Commands_Awake = 0x0b,
-    DfMp3_Commands_Reset = 0x0c,
-    DfMp3_Commands_Start = 0x0d,
-    DfMp3_Commands_Pause = 0x0e,
-    DfMp3_Commands_PlayFolderTrack = 0x0f,
-    DfMp3_Commands_RepeatPlayInRoot = 0x11,
-    DfMp3_Commands_PlayMp3FolderTrack = 0x12,
-    DfMp3_Commands_PlayAdvertTrack = 0x13,
-    DfMp3_Commands_PlayFolderTrack16 = 0x14,
-    DfMp3_Commands_StopAdvert = 0x15,
-    DfMp3_Commands_Stop = 0x16,
-    DfMp3_Commands_LoopInFolder = 0x17,
-    DfMp3_Commands_PlayRandmomGlobalTrack = 0x18,
-    DfMp3_Commands_RepeatPlayCurrentTrack = 0x19,
-    DfMp3_Commands_SetDacInactive = 0x1a,
-    DfMp3_Commands_GetPlaySources = 0x3f,
-    DfMp3_Commands_Error = 0x40,
-    DfMp3_Commands_Ack = 0x41,
-    DfMp3_Commands_GetStatus = 0x42,
-    DfMp3_Commands_GetVolume = 0x43,
-    DfMp3_Commands_GetEq = 0x44,
-    DfMp3_Commands_GetPlaybackMode = 0x45,
-    DfMp3_Commands_GetUsbTrackount = 0x47,
-    DfMp3_Commands_GetSdTrackount = 0x48,
-    DfMp3_Commands_GetFlashTrackount = 0x49,
-    DfMp3_Commands_GetUsbCurrentTrack = 0x4b,
-    DfMp3_Commands_GetSdCurrentTrack = 0x4c,
-    DfMp3_Commands_GetFlashCurrentTrack = 0x4d,
-    DfMp3_Commands_GetFolderTrackCount = 0x4e,
-    DfMp3_Commands_GetTotalFolderCount = 0x4f,
-};
+#include "DfMp3Types.h"
+#include "Mp3Packet.h"
+#include "Mp3ChipBase.h"
+#include "Mp3ChipOriginal.h"
+#include "Mp3ChipMH2024K16SS.h"
 
-enum DfMp3_Error
-{
-    //                              alternative meanings depending on chip
-    // from device                
-    DfMp3_Error_Busy = 1,         //  busy                  busy
-    DfMp3_Error_Sleeping,         //  frame not received    sleep
-    DfMp3_Error_SerialWrongStack, //  verification error    frame not received
-    DfMp3_Error_CheckSumNotMatch, //                        checksum
-    DfMp3_Error_FileIndexOut,     //                        track out of scope
-    DfMp3_Error_FileMismatch,     //                        track not found
-    DfMp3_Error_Advertise,        //                        only allowed while playing     advertisement not allowed
-    DfMp3_Error_SdReadFail,        //                        SD card failed
-    DfMp3_Error_EnteredSleep = 10, //                        entered sleep    
-    // from library
-    DfMp3_Error_RxTimeout = 0x81,
-    DfMp3_Error_PacketSize,
-    DfMp3_Error_PacketHeader,
-    DfMp3_Error_PacketChecksum,
-    DfMp3_Error_General = 0xff
-};
-
-enum DfMp3_PlaybackMode
-{
-    DfMp3_PlaybackMode_Repeat,
-    DfMp3_PlaybackMode_FolderRepeat,
-    DfMp3_PlaybackMode_SingleRepeat,
-    DfMp3_PlaybackMode_Random
-};
-
-enum DfMp3_Eq
-{
-    DfMp3_Eq_Normal,
-    DfMp3_Eq_Pop,
-    DfMp3_Eq_Rock,
-    DfMp3_Eq_Jazz,
-    DfMp3_Eq_Classic,
-    DfMp3_Eq_Bass
-};
-
-enum DfMp3_PlaySource // value - only one can be set
-{
-    DfMp3_PlaySource_Usb = 1,
-    DfMp3_PlaySource_Sd,
-    DfMp3_PlaySource_Aux,
-    DfMp3_PlaySource_Sleep,
-    DfMp3_PlaySource_Flash
-};
-
-enum DfMp3_PlaySources // bitfield - more than one can be set
-{
-    DfMp3_PlaySources_Usb = 0x01,
-    DfMp3_PlaySources_Sd = 0x02,
-    DfMp3_PlaySources_Pc = 0x04,
-    DfMp3_PlaySources_Flash = 0x08,
-};
-
-enum DfMp3_StatusState
-{
-    DfMp3_StatusState_Idle = 0x00,
-    DfMp3_StatusState_Playing = 0x01,
-    DfMp3_StatusState_Paused = 0x02,
-    DfMp3_StatusState_Sleep = 0x08, // note, some chips use DfMp3_StatusSource_Sleep
-    DfMp3_StatusState_Shuffling = 0x11, // not documented, but discovered
-};
-
-enum DfMp3_StatusSource
-{
-    DfMp3_StatusSource_General = 0x00,
-    DfMp3_StatusSource_Usb = 0x01,
-    DfMp3_StatusSource_Sd = 0x02,
-    DfMp3_StatusSource_Sleep = 0x10,
-};
-
-struct DfMp3_Status
-{
-    DfMp3_StatusSource source;
-    DfMp3_StatusState state;
-};
-
-const uint8_t DfMp3_PacketStartCode = 0x7e;
-const uint8_t DfMp3_PacketVersion = 0xff;
-const uint8_t DfMp3_PacketEndCode = 0xef;
-
-// 7E FF 06 0F 00 01 01 xx xx EF
-// 0	->	7E is start code
-// 1	->	FF is version
-// 2	->	06 is length
-// 3	->	0F is command
-// 4	->	00 is no receive
-// 5~6	->	01 01 is argument
-// 7~8	->	checksum = 0 - ( FF+06+0F+00+01+01 )
-// 9	->	EF is end code
-struct DfMp3_Packet_WithCheckSum
-{
-    uint8_t startCode;
-    uint8_t version;
-    uint8_t length;
-    uint8_t command;
-    uint8_t requestAck;
-    uint8_t hiByteArgument;
-    uint8_t lowByteArgument;
-    uint8_t hiByteCheckSum;
-    uint8_t lowByteCheckSum;
-    uint8_t endCode;
-};
-
-// 7E FF 06 0F 00 01 01 EF
-// 0	->	7E is start code
-// 1	->	FF is version
-// 2	->	06 is length
-// 3	->	0F is command
-// 4	->	00 is no receive
-// 5~6	->	01 01 is argument
-// 7	->	EF is end code
-struct DfMp3_Packet_WithoutCheckSum
-{
-    uint8_t startCode;
-    uint8_t version;
-    uint8_t length;
-    uint8_t command;
-    uint8_t requestAck;
-    uint8_t hiByteArgument;
-    uint8_t lowByteArgument;
-    uint8_t endCode;
-};
-
-class Mp3ChipBase
-{
-private:
-    static uint16_t calcChecksum(const DfMp3_Packet_WithCheckSum& packet)
-    {
-        uint16_t sum = 0xFFFF;
-        for (const uint8_t* packetByte = &(packet.version); packetByte != &(packet.hiByteCheckSum); packetByte++)
-        {
-            sum -= *packetByte;
-        }
-        return sum + 1;
-    }
-
-public:
-    static void setChecksum(DfMp3_Packet_WithCheckSum* out)
-    {
-        uint16_t sum = calcChecksum(*out);
-
-        out->hiByteCheckSum = (sum >> 8);
-        out->lowByteCheckSum = (sum & 0xff);
-    }
-
-    static bool validateChecksum(const DfMp3_Packet_WithCheckSum& in)
-    {
-        uint16_t sum = calcChecksum(in);
-        return (sum == ((static_cast<uint16_t>(in.hiByteCheckSum) << 8) | in.lowByteCheckSum));
-    }
-};
-
-class Mp3ChipMH2024K16SS : public Mp3ChipBase 
-{
-public:
-    static const bool SendCheckSum = false;
-
-    typedef DfMp3_Packet_WithoutCheckSum SendPacket;
-    typedef DfMp3_Packet_WithCheckSum ReceptionPacket;
-
-    static const SendPacket generatePacket(uint8_t command, uint16_t arg, bool requestAck = false) 
-    {
-        return {
-            DfMp3_PacketStartCode,
-            DfMp3_PacketVersion,
-            6, // size: of what?  without checksum this doesn't make sense
-            command,
-            requestAck,
-            static_cast<uint8_t>(arg >> 8),
-            static_cast<uint8_t>(arg & 0x00ff),
-            DfMp3_PacketEndCode };
-    }
-};
-
-class Mp3ChipOriginal : public Mp3ChipBase 
-{
-public:
-    static const bool SendCheckSum = true;
-
-    typedef DfMp3_Packet_WithCheckSum SendPacket;
-    typedef DfMp3_Packet_WithCheckSum ReceptionPacket;
-
-    static const SendPacket generatePacket(uint8_t command, uint16_t arg, bool requestAck = false)
-    {
-        SendPacket packet = {
-                DfMp3_PacketStartCode,
-                DfMp3_PacketVersion,
-                6, // size, remaining bytes not including end code
-                command,
-                requestAck,
-                static_cast<uint8_t>(arg >> 8),
-                static_cast<uint8_t>(arg & 0x00ff),
-                0, // checksum calculated below
-                0, // checksum calculated below
-                DfMp3_PacketEndCode };
-        setChecksum(&packet);
-        return packet;
-    }
-};
 
 template <class T_SERIAL_METHOD, class T_NOTIFICATION_METHOD, class T_CHIP_VARIANT = Mp3ChipOriginal>
 class DFMiniMp3
@@ -300,7 +58,7 @@ public:
     {
         while (_serial.available() >= static_cast<int>(sizeof(typename T_CHIP_VARIANT::ReceptionPacket)))
         {
-            listenForReply(DfMp3_Commands_None);
+            listenForReply(Mp3_Commands_None);
         }
     }
 
@@ -309,19 +67,19 @@ public:
     // MH2024K-24SS - sends NO reply --> results in error notification
     DfMp3_PlaySources getPlaySources()
     {
-        return getCommand(DfMp3_Commands_GetPlaySources).arg;
+        return getCommand(Mp3_Commands_GetPlaySources).arg;
     }
 
     // the track as enumerated across all folders
     void playGlobalTrack(uint16_t track = 0)
     {
-        setCommand(DfMp3_Commands_PlayGlobalTrack, track);
+        setCommand(Mp3_Commands_PlayGlobalTrack, track);
     }
 
     // sd:/mp3/####track name
     void playMp3FolderTrack(uint16_t track)
     {
-        setCommand(DfMp3_Commands_PlayMp3FolderTrack, track);
+        setCommand(Mp3_Commands_PlayMp3FolderTrack, track);
     }
 
     // older devices: sd:/###/###track name
@@ -330,7 +88,7 @@ public:
     void playFolderTrack(uint8_t folder, uint8_t track)
     {
         uint16_t arg = (folder << 8) | track;
-        setCommand(DfMp3_Commands_PlayFolderTrack, arg);
+        setCommand(Mp3_Commands_PlayFolderTrack, arg);
     }
 
     // sd:/##/####track name
@@ -338,22 +96,22 @@ public:
     void playFolderTrack16(uint8_t folder, uint16_t track)
     {
         uint16_t arg = (static_cast<uint16_t>(folder) << 12) | track;
-        setCommand(DfMp3_Commands_PlayFolderTrack16, arg);
+        setCommand(Mp3_Commands_PlayFolderTrack16, arg);
     }
 
     void playRandomTrackFromAll()
     {
-        setCommand(DfMp3_Commands_PlayRandmomGlobalTrack);
+        setCommand(Mp3_Commands_PlayRandmomGlobalTrack);
     }
 
     void nextTrack()
     {
-        setCommand(DfMp3_Commands_PlayNextTrack);
+        setCommand(Mp3_Commands_PlayNextTrack);
     }
 
     void prevTrack()
     {
-        setCommand(DfMp3_Commands_PlayPrevTrack);
+        setCommand(Mp3_Commands_PlayPrevTrack);
     }
 
     uint16_t getCurrentTrack(DfMp3_PlaySource source = DfMp3_PlaySource_Sd)
@@ -363,16 +121,16 @@ public:
         switch (source)
         {
         case DfMp3_PlaySource_Usb:
-            command = DfMp3_Commands_GetUsbCurrentTrack;
+            command = Mp3_Commands_GetUsbCurrentTrack;
             break;
         case DfMp3_PlaySource_Sd:
-            command = DfMp3_Commands_GetSdCurrentTrack;
+            command = Mp3_Commands_GetSdCurrentTrack;
             break;
         case DfMp3_PlaySource_Flash:
-            command = DfMp3_Commands_GetFlashCurrentTrack;
+            command = Mp3_Commands_GetFlashCurrentTrack;
             break;
         default:
-            command = DfMp3_Commands_GetSdCurrentTrack;
+            command = Mp3_Commands_GetSdCurrentTrack;
             break;
         }
 
@@ -382,22 +140,22 @@ public:
     // 0- 30
     void setVolume(uint8_t volume)
     {
-        setCommand(DfMp3_Commands_SetVolume, volume);
+        setCommand(Mp3_Commands_SetVolume, volume);
     }
 
     uint8_t getVolume()
     {
-        return getCommand(DfMp3_Commands_GetVolume).arg;
+        return getCommand(Mp3_Commands_GetVolume).arg;
     }
 
     void increaseVolume()
     {
-        setCommand(DfMp3_Commands_IncVolume);
+        setCommand(Mp3_Commands_IncVolume);
     }
 
     void decreaseVolume()
     {
-        setCommand(DfMp3_Commands_DecVolume);
+        setCommand(Mp3_Commands_DecVolume);
     }
 
     // useless, removed
@@ -412,86 +170,86 @@ public:
 
     void loopGlobalTrack(uint16_t globalTrack)
     {
-        setCommand(DfMp3_Commands_LoopGlobalTrack, globalTrack);
+        setCommand(Mp3_Commands_LoopGlobalTrack, globalTrack);
     }
 
     // sd:/##/*
     // 0-99
     void loopFolder(uint8_t folder)
     {
-        setCommand(DfMp3_Commands_LoopInFolder, folder);
+        setCommand(Mp3_Commands_LoopInFolder, folder);
     }
 
     // not well supported, use at your own risk
     void setPlaybackMode(DfMp3_PlaybackMode mode)
     {
-        setCommand(DfMp3_Commands_SetPlaybackMode, mode);
+        setCommand(Mp3_Commands_SetPlaybackMode, mode);
     }
 
     DfMp3_PlaybackMode getPlaybackMode()
     {
-        return static_cast<DfMp3_PlaybackMode>(getCommand(DfMp3_Commands_GetPlaybackMode).arg);
+        return static_cast<DfMp3_PlaybackMode>(getCommand(Mp3_Commands_GetPlaybackMode).arg);
     }
 
     void setRepeatPlayAllInRoot(bool repeat)
     {
-        setCommand(DfMp3_Commands_RepeatPlayInRoot, !!repeat);
+        setCommand(Mp3_Commands_RepeatPlayInRoot, !!repeat);
     }
 
     void setRepeatPlayCurrentTrack(bool repeat)
     {
-        setCommand(DfMp3_Commands_RepeatPlayCurrentTrack, !repeat);
+        setCommand(Mp3_Commands_RepeatPlayCurrentTrack, !repeat);
     }
 
     void setEq(DfMp3_Eq eq)
     {
-        setCommand(DfMp3_Commands_SetEq, eq);
+        setCommand(Mp3_Commands_SetEq, eq);
     }
 
     DfMp3_Eq getEq()
     {
-        return static_cast<DfMp3_Eq>(getCommand(DfMp3_Commands_GetEq).arg);
+        return static_cast<DfMp3_Eq>(getCommand(Mp3_Commands_GetEq).arg);
     }
 
     void setPlaybackSource(DfMp3_PlaySource source)
     {
-        setCommand(DfMp3_Commands_SetPlaybackSource, source);
+        setCommand(Mp3_Commands_SetPlaybackSource, source);
     }
 
     void sleep()
     {
-        setCommand(DfMp3_Commands_Sleep);
+        setCommand(Mp3_Commands_Sleep);
     }
 
     void awake()
     {
-        setCommand(DfMp3_Commands_Awake);
+        setCommand(Mp3_Commands_Awake);
     }
 
     void reset()
     {
-        setCommand(DfMp3_Commands_Reset);
+        setCommand(Mp3_Commands_Reset);
         _isOnline = false;
     }
 
     void start()
     {
-        setCommand(DfMp3_Commands_Start);
+        setCommand(Mp3_Commands_Start);
     }
 
     void pause()
     {
-        setCommand(DfMp3_Commands_Pause);
+        setCommand(Mp3_Commands_Pause);
     }
 
     void stop()
     {
-        setCommand(DfMp3_Commands_Stop);
+        setCommand(Mp3_Commands_Stop);
     }
 
     DfMp3_Status getStatus()
     {
-        uint16_t reply = getCommand(DfMp3_Commands_GetStatus).arg;
+        uint16_t reply = getCommand(Mp3_Commands_GetStatus).arg;
 
         DfMp3_Status status;
         status.source = static_cast<DfMp3_StatusSource>(reply >> 8);
@@ -502,7 +260,7 @@ public:
 
     uint16_t getFolderTrackCount(uint16_t folder)
     {
-        return getCommand(DfMp3_Commands_GetFolderTrackCount).arg;
+        return getCommand(Mp3_Commands_GetFolderTrackCount).arg;
     }
 
     uint16_t getTotalTrackCount(DfMp3_PlaySource source = DfMp3_PlaySource_Sd)
@@ -512,16 +270,16 @@ public:
         switch (source)
         {
         case DfMp3_PlaySource_Usb:
-            command = DfMp3_Commands_GetUsbTrackount;
+            command = Mp3_Commands_GetUsbTrackount;
             break;
         case DfMp3_PlaySource_Sd:
-            command = DfMp3_Commands_GetSdTrackount;
+            command = Mp3_Commands_GetSdTrackount;
             break;
         case DfMp3_PlaySource_Flash:
-            command = DfMp3_Commands_GetFlashTrackount;
+            command = Mp3_Commands_GetFlashTrackount;
             break;
         default:
-            command = DfMp3_Commands_GetSdTrackount;
+            command = Mp3_Commands_GetSdTrackount;
             break;
         }
 
@@ -530,28 +288,28 @@ public:
 
     uint16_t getTotalFolderCount()
     {
-        return getCommand(DfMp3_Commands_GetTotalFolderCount).arg;
+        return getCommand(Mp3_Commands_GetTotalFolderCount).arg;
     }
 
     // sd:/advert/####track name
     void playAdvertisement(uint16_t track)
     {
-        setCommand(DfMp3_Commands_PlayAdvertTrack, track);
+        setCommand(Mp3_Commands_PlayAdvertTrack, track);
     }
 
     void stopAdvertisement()
     {
-        setCommand(DfMp3_Commands_StopAdvert);
+        setCommand(Mp3_Commands_StopAdvert);
     }
 
     void enableDac()
     {
-        setCommand(DfMp3_Commands_SetDacInactive, 0x00);
+        setCommand(Mp3_Commands_SetDacInactive, 0x00);
     }
 
     void disableDac()
     {
-        setCommand(DfMp3_Commands_SetDacInactive, 0x01);
+        setCommand(Mp3_Commands_SetDacInactive, 0x01);
     }
 
     bool isOnline() const
@@ -574,7 +332,7 @@ private:
     {
         while (_serial.available() > 0)
         {
-            listenForReply(DfMp3_Commands_None);
+            listenForReply(Mp3_Commands_None);
         }
     }
 
@@ -615,6 +373,13 @@ private:
         } while (in.startCode != 0x7e);
 
         read += _serial.readBytes(&in.version, sizeof(in) - 1);
+
+#ifdef DfMiniMp3Debug
+        DfMiniMp3Debug.print("IN ");
+        printRawPacket(reinterpret_cast<const uint8_t*>(&in), read);
+        DfMiniMp3Debug.println();
+#endif
+
         if (read < sizeof(in))
         {
             // not enough bytes, corrupted packet
@@ -637,12 +402,6 @@ private:
             reply->arg = DfMp3_Error_PacketChecksum;
             return false;
         }
-
-#ifdef DfMiniMp3Debug
-        DfMiniMp3Debug.print("IN ");
-        printRawPacket(reinterpret_cast<const uint8_t*>(&in), sizeof(in));
-        DfMiniMp3Debug.println();
-#endif
 
         reply->command = in.command;
         reply->arg = ((static_cast<uint16_t>(in.hiByteArgument) << 8) | in.lowByteArgument);
@@ -667,7 +426,7 @@ private:
             retries--;
         } while (reply.command != expectedCommand && retries);
 
-        if (reply.command == DfMp3_Commands_Error)
+        if (reply.command == Mp3_Commands_Error)
         {
             T_NOTIFICATION_METHOD::OnError(*this, reply.arg);
             reply = { 0 };
@@ -683,7 +442,7 @@ private:
 
     void setCommand(uint8_t command, uint16_t arg = 0)
     {
-        retryCommand(command, DfMp3_Commands_Ack, arg, true);
+        retryCommand(command, Mp3_Commands_Ack, arg, true);
     }
 
     reply_t listenForReply(uint8_t command)
@@ -723,16 +482,16 @@ private:
                 T_NOTIFICATION_METHOD::OnPlaySourceRemoved(*this, static_cast<DfMp3_PlaySources>(reply.arg));
                 break;
 
-            case DfMp3_Commands_Error: // error
-                if (command == DfMp3_Commands_None)
+            case Mp3_Commands_Error: // error
+                if (command == Mp3_Commands_None)
                 {
                     T_NOTIFICATION_METHOD::OnError(*this, reply.arg);
                 }
                 // fall through
-            case DfMp3_Commands_Ack: // ack
+            case Mp3_Commands_Ack: // ack
                 // fall through
             default:
-                if (command != DfMp3_Commands_None)
+                if (command != Mp3_Commands_None)
                 {
                     return reply;
                 }

--- a/src/DFMiniMp3.h
+++ b/src/DFMiniMp3.h
@@ -150,6 +150,10 @@ struct DfMp3_Status
     DfMp3_StatusState state;
 };
 
+const uint8_t DfMp3_PacketStartCode = 0x7e;
+const uint8_t DfMp3_PacketVersion = 0xff;
+const uint8_t DfMp3_PacketEndCode = 0xef;
+
 // 7E FF 06 0F 00 01 01 xx xx EF
 // 0	->	7E is start code
 // 1	->	FF is version
@@ -233,14 +237,14 @@ public:
     static const SendPacket generatePacket(uint8_t command, uint16_t arg, bool requestAck = false) 
     {
         return {
-            0x7E,
-            0xFF,
-            6,
+            DfMp3_PacketStartCode,
+            DfMp3_PacketVersion,
+            6, // size: of what?  without checksum this doesn't make sense
             command,
             requestAck,
             static_cast<uint8_t>(arg >> 8),
             static_cast<uint8_t>(arg & 0x00ff),
-            0xEF };
+            DfMp3_PacketEndCode };
     }
 };
 
@@ -255,16 +259,16 @@ public:
     static const SendPacket generatePacket(uint8_t command, uint16_t arg, bool requestAck = false)
     {
         SendPacket packet = {
-                0x7E,
-                0xFF,
-                6,
+                DfMp3_PacketStartCode,
+                DfMp3_PacketVersion,
+                6, // size, remaining bytes not including end code
                 command,
                 requestAck,
                 static_cast<uint8_t>(arg >> 8),
                 static_cast<uint8_t>(arg & 0x00ff),
-                0,
-                0,
-                0xEF };
+                0, // checksum calculated below
+                0, // checksum calculated below
+                DfMp3_PacketEndCode };
         setChecksum(&packet);
         return packet;
     }

--- a/src/DfMp3Types.h
+++ b/src/DfMp3Types.h
@@ -1,0 +1,108 @@
+/*-------------------------------------------------------------------------
+DfMp3Types - API exposed support enums and structs
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/DFMiniMp3)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/DFMiniMp3 library.
+
+DFMiniMp3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+DFMiniMp3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with DFMiniMp3.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+#pragma once
+
+
+enum DfMp3_Error
+{
+    //                              alternative meanings depending on chip
+    // from device                
+    DfMp3_Error_Busy = 1,         //  busy                  busy
+    DfMp3_Error_Sleeping,         //  frame not received    sleep
+    DfMp3_Error_SerialWrongStack, //  verification error    frame not received
+    DfMp3_Error_CheckSumNotMatch, //                        checksum
+    DfMp3_Error_FileIndexOut,     //                        track out of scope
+    DfMp3_Error_FileMismatch,     //                        track not found
+    DfMp3_Error_Advertise,        //                        only allowed while playing     advertisement not allowed
+    DfMp3_Error_SdReadFail,        //                        SD card failed
+    DfMp3_Error_EnteredSleep = 10, //                        entered sleep    
+    // from library
+    DfMp3_Error_RxTimeout = 0x81,
+    DfMp3_Error_PacketSize,
+    DfMp3_Error_PacketHeader,
+    DfMp3_Error_PacketChecksum,
+    DfMp3_Error_General = 0xff
+};
+
+enum DfMp3_PlaybackMode
+{
+    DfMp3_PlaybackMode_Repeat,
+    DfMp3_PlaybackMode_FolderRepeat,
+    DfMp3_PlaybackMode_SingleRepeat,
+    DfMp3_PlaybackMode_Random
+};
+
+enum DfMp3_Eq
+{
+    DfMp3_Eq_Normal,
+    DfMp3_Eq_Pop,
+    DfMp3_Eq_Rock,
+    DfMp3_Eq_Jazz,
+    DfMp3_Eq_Classic,
+    DfMp3_Eq_Bass
+};
+
+enum DfMp3_PlaySource // value - only one can be set
+{
+    DfMp3_PlaySource_Usb = 1,
+    DfMp3_PlaySource_Sd,
+    DfMp3_PlaySource_Aux,
+    DfMp3_PlaySource_Sleep,
+    DfMp3_PlaySource_Flash
+};
+
+enum DfMp3_PlaySources // bitfield - more than one can be set
+{
+    DfMp3_PlaySources_Usb = 0x01,
+    DfMp3_PlaySources_Sd = 0x02,
+    DfMp3_PlaySources_Pc = 0x04,
+    DfMp3_PlaySources_Flash = 0x08,
+};
+
+enum DfMp3_StatusState
+{
+    DfMp3_StatusState_Idle = 0x00,
+    DfMp3_StatusState_Playing = 0x01,
+    DfMp3_StatusState_Paused = 0x02,
+    DfMp3_StatusState_Sleep = 0x08, // note, some chips use DfMp3_StatusSource_Sleep
+    DfMp3_StatusState_Shuffling = 0x11, // not documented, but discovered
+};
+
+enum DfMp3_StatusSource
+{
+    DfMp3_StatusSource_General = 0x00,
+    DfMp3_StatusSource_Usb = 0x01,
+    DfMp3_StatusSource_Sd = 0x02,
+    DfMp3_StatusSource_Sleep = 0x10,
+};
+
+struct DfMp3_Status
+{
+    DfMp3_StatusSource source;
+    DfMp3_StatusState state;
+};
+

--- a/src/Mp3ChipBase.h
+++ b/src/Mp3ChipBase.h
@@ -1,0 +1,57 @@
+/*-------------------------------------------------------------------------
+Mp3ChipBase - base class to T_CHIP_VARIANT template features
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/DFMiniMp3)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/DFMiniMp3 library.
+
+DFMiniMp3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+DFMiniMp3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with DFMiniMp3.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+#pragma once
+
+
+class Mp3ChipBase
+{
+private:
+    static uint16_t calcChecksum(const Mp3_Packet_WithCheckSum& packet)
+    {
+        uint16_t sum = 0xFFFF;
+        for (const uint8_t* packetByte = &(packet.version); packetByte != &(packet.hiByteCheckSum); packetByte++)
+        {
+            sum -= *packetByte;
+        }
+        return sum + 1;
+    }
+
+public:
+    static void setChecksum(Mp3_Packet_WithCheckSum* out)
+    {
+        uint16_t sum = calcChecksum(*out);
+
+        out->hiByteCheckSum = (sum >> 8);
+        out->lowByteCheckSum = (sum & 0xff);
+    }
+
+    static bool validateChecksum(const Mp3_Packet_WithCheckSum& in)
+    {
+        uint16_t sum = calcChecksum(in);
+        return (sum == ((static_cast<uint16_t>(in.hiByteCheckSum) << 8) | in.lowByteCheckSum));
+    }
+};

--- a/src/Mp3ChipMH2024K16SS.h
+++ b/src/Mp3ChipMH2024K16SS.h
@@ -1,0 +1,50 @@
+/*-------------------------------------------------------------------------
+Mp3ChipMH2024K16SS - chip class for T_CHIP_VARIANT template features
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/DFMiniMp3)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/DFMiniMp3 library.
+
+DFMiniMp3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+DFMiniMp3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with DFMiniMp3.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+
+#pragma once
+
+class Mp3ChipMH2024K16SS : public Mp3ChipBase
+{
+public:
+    static const bool SendCheckSum = false;
+
+    typedef Mp3_Packet_WithoutCheckSum SendPacket;
+    typedef Mp3_Packet_WithCheckSum ReceptionPacket;
+
+    static const SendPacket generatePacket(uint8_t command, uint16_t arg, bool requestAck = false)
+    {
+        return {
+            Mp3_PacketStartCode,
+            Mp3_PacketVersion,
+            6, // size: of what?  without checksum this doesn't make sense
+            command,
+            requestAck,
+            static_cast<uint8_t>(arg >> 8),
+            static_cast<uint8_t>(arg & 0x00ff),
+            Mp3_PacketEndCode };
+    }
+};

--- a/src/Mp3ChipOriginal.h
+++ b/src/Mp3ChipOriginal.h
@@ -1,0 +1,53 @@
+/*-------------------------------------------------------------------------
+Mp3ChipOriginal - chip class for T_CHIP_VARIANT template features
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/DFMiniMp3)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/DFMiniMp3 library.
+
+DFMiniMp3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+DFMiniMp3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with DFMiniMp3.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+#pragma once
+
+
+class Mp3ChipOriginal : public Mp3ChipBase
+{
+public:
+    static const bool SendCheckSum = true;
+
+    typedef Mp3_Packet_WithCheckSum SendPacket;
+    typedef Mp3_Packet_WithCheckSum ReceptionPacket;
+
+    static const SendPacket generatePacket(uint8_t command, uint16_t arg, bool requestAck = false)
+    {
+        SendPacket packet = {
+                Mp3_PacketStartCode,
+                Mp3_PacketVersion,
+                6, // size, remaining bytes not including end code
+                command,
+                requestAck,
+                static_cast<uint8_t>(arg >> 8),
+                static_cast<uint8_t>(arg & 0x00ff),
+                0, // checksum calculated below
+                0, // checksum calculated below
+                Mp3_PacketEndCode };
+        setChecksum(&packet);
+        return packet;
+    }
+};

--- a/src/Mp3Packet.h
+++ b/src/Mp3Packet.h
@@ -55,13 +55,12 @@ enum Mp3_Commands
     Mp3_Commands_PlayRandmomGlobalTrack = 0x18,
     Mp3_Commands_RepeatPlayCurrentTrack = 0x19,
     Mp3_Commands_SetDacInactive = 0x1a,
-    Mp3_Commands_GetPlaySources = 0x3f,
-    Mp3_Commands_Error = 0x40,
-    Mp3_Commands_Ack = 0x41,
+    Mp3_Commands_GetPlaySources = 0x3f, // deprecated due to conflict with replies
     Mp3_Commands_GetStatus = 0x42,
     Mp3_Commands_GetVolume = 0x43,
     Mp3_Commands_GetEq = 0x44,
     Mp3_Commands_GetPlaybackMode = 0x45,
+    Mp3_Commands_GetSoftwareVersion = 0x46,
     Mp3_Commands_GetUsbTrackount = 0x47,
     Mp3_Commands_GetSdTrackount = 0x48,
     Mp3_Commands_GetFlashTrackount = 0x49,
@@ -70,6 +69,19 @@ enum Mp3_Commands
     Mp3_Commands_GetFlashCurrentTrack = 0x4d,
     Mp3_Commands_GetFolderTrackCount = 0x4e,
     Mp3_Commands_GetTotalFolderCount = 0x4f,
+};
+
+
+enum Mp3_Replies
+{
+    Mp3_Replies_PlaySource_Inserted = 0x3a,
+    Mp3_Replies_PlaySource_Removed = 0x3b,
+    Mp3_Replies_TrackFinished_Usb = 0x3c,
+    Mp3_Replies_TrackFinished_Sd = 0x3d,
+    Mp3_Replies_TrackFinished_Flash = 0x3e,
+    Mp3_Replies_PlaySource_Online = 0x3f,
+    Mp3_Replies_Error = 0x40,
+    Mp3_Replies_Ack = 0x41,
 };
 
 const uint8_t Mp3_PacketStartCode = 0x7e;

--- a/src/Mp3Packet.h
+++ b/src/Mp3Packet.h
@@ -1,0 +1,120 @@
+/*-------------------------------------------------------------------------
+Mp3Packet - packet specific enums and structures
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/DFMiniMp3)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/DFMiniMp3 library.
+
+DFMiniMp3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+DFMiniMp3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with DFMiniMp3.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+
+#pragma once
+
+enum Mp3_Commands
+{
+    Mp3_Commands_None = 0x00,
+    Mp3_Commands_PlayNextTrack = 0x01,
+    Mp3_Commands_PlayPrevTrack = 0x02,
+    Mp3_Commands_PlayGlobalTrack = 0x03,
+    Mp3_Commands_IncVolume = 0x04,
+    Mp3_Commands_DecVolume = 0x05,
+    Mp3_Commands_SetVolume = 0x06,
+    Mp3_Commands_SetEq = 0x07,
+    Mp3_Commands_LoopGlobalTrack = 0x08,
+    Mp3_Commands_SetPlaybackMode = 0x08,
+    Mp3_Commands_SetPlaybackSource = 0x09,
+    Mp3_Commands_Sleep = 0x0a,
+    Mp3_Commands_Awake = 0x0b,
+    Mp3_Commands_Reset = 0x0c,
+    Mp3_Commands_Start = 0x0d,
+    Mp3_Commands_Pause = 0x0e,
+    Mp3_Commands_PlayFolderTrack = 0x0f,
+    Mp3_Commands_RepeatPlayInRoot = 0x11,
+    Mp3_Commands_PlayMp3FolderTrack = 0x12,
+    Mp3_Commands_PlayAdvertTrack = 0x13,
+    Mp3_Commands_PlayFolderTrack16 = 0x14,
+    Mp3_Commands_StopAdvert = 0x15,
+    Mp3_Commands_Stop = 0x16,
+    Mp3_Commands_LoopInFolder = 0x17,
+    Mp3_Commands_PlayRandmomGlobalTrack = 0x18,
+    Mp3_Commands_RepeatPlayCurrentTrack = 0x19,
+    Mp3_Commands_SetDacInactive = 0x1a,
+    Mp3_Commands_GetPlaySources = 0x3f,
+    Mp3_Commands_Error = 0x40,
+    Mp3_Commands_Ack = 0x41,
+    Mp3_Commands_GetStatus = 0x42,
+    Mp3_Commands_GetVolume = 0x43,
+    Mp3_Commands_GetEq = 0x44,
+    Mp3_Commands_GetPlaybackMode = 0x45,
+    Mp3_Commands_GetUsbTrackount = 0x47,
+    Mp3_Commands_GetSdTrackount = 0x48,
+    Mp3_Commands_GetFlashTrackount = 0x49,
+    Mp3_Commands_GetUsbCurrentTrack = 0x4b,
+    Mp3_Commands_GetSdCurrentTrack = 0x4c,
+    Mp3_Commands_GetFlashCurrentTrack = 0x4d,
+    Mp3_Commands_GetFolderTrackCount = 0x4e,
+    Mp3_Commands_GetTotalFolderCount = 0x4f,
+};
+
+const uint8_t Mp3_PacketStartCode = 0x7e;
+const uint8_t Mp3_PacketVersion = 0xff;
+const uint8_t Mp3_PacketEndCode = 0xef;
+
+// 7E FF 06 0F 00 01 01 xx xx EF
+// 0	->	7E is start code
+// 1	->	FF is version
+// 2	->	06 is length
+// 3	->	0F is command
+// 4	->	00 is no receive
+// 5~6	->	01 01 is argument
+// 7~8	->	checksum = 0 - ( FF+06+0F+00+01+01 )
+// 9	->	EF is end code
+struct Mp3_Packet_WithCheckSum
+{
+    uint8_t startCode;
+    uint8_t version;
+    uint8_t length;
+    uint8_t command;
+    uint8_t requestAck;
+    uint8_t hiByteArgument;
+    uint8_t lowByteArgument;
+    uint8_t hiByteCheckSum;
+    uint8_t lowByteCheckSum;
+    uint8_t endCode;
+};
+
+// 7E FF 06 0F 00 01 01 EF
+// 0	->	7E is start code
+// 1	->	FF is version
+// 2	->	06 is length
+// 3	->	0F is command
+// 4	->	00 is no receive
+// 5~6	->	01 01 is argument
+// 7	->	EF is end code
+struct Mp3_Packet_WithoutCheckSum
+{
+    uint8_t startCode;
+    uint8_t version;
+    uint8_t length;
+    uint8_t command;
+    uint8_t requestAck;
+    uint8_t hiByteArgument;
+    uint8_t lowByteArgument;
+    uint8_t endCode;
+};

--- a/src/queueSimple.h
+++ b/src/queueSimple.h
@@ -1,0 +1,128 @@
+/*-------------------------------------------------------------------------
+queueSimple_t - simple vector queue, as not all Arduino have stl types available 
+
+Written by Michael C. Miller.
+
+I invest time and resources providing this open source code,
+please support me by dontating (see https://github.com/Makuna/DFMiniMp3)
+
+-------------------------------------------------------------------------
+This file is part of the Makuna/DFMiniMp3 library.
+
+DFMiniMp3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+DFMiniMp3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with DFMiniMp3.  If not, see
+<http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------*/
+#pragma once
+
+template <class T_ITEM> class queueSimple_t
+{
+public:
+    queueSimple_t(uint8_t length) :
+        _queue(nullptr),
+        _length(0),
+        _front(0),
+        _back(0)
+    {
+        enlarge(length);
+    }
+
+    ~queueSimple_t()
+    {
+        delete[] _queue;
+        _queue = nullptr;
+    }
+
+    void Enqueue(const T_ITEM& item)
+    {
+        //Serial.print("Enqueue (");
+        //item.printReply();
+        //Serial.print(") front(");
+        //Serial.print(_front);
+        //Serial.print(") back(");
+        //Serial.print(_back);
+        //Serial.println(")");
+
+        uint8_t newBack = _back + 1;
+        if (newBack >= _length)
+        {
+            newBack = 0;
+        }
+
+        if (newBack == _front)
+        {
+            // no space left, enlarge
+            enlarge(_length + 2);
+            newBack = _back + 1;
+        }
+        _queue[_back] = item;
+        _back = newBack;
+    }
+
+    bool Dequeue(T_ITEM* item)
+    {
+        *item = { 0 };
+
+        if (_front == _back)
+        {
+            return false;
+        }
+
+        *item = _queue[_front];
+        _front++;
+        if (_front >= _length)
+        {
+            _front = 0;
+        }
+
+        return true;
+    }
+
+private:
+    T_ITEM* _queue;
+    uint8_t _length;
+    uint8_t _front; // location of removing present items
+    uint8_t _back; // location of appending new items
+
+    void enlarge(uint8_t newLength)
+    {
+#ifdef DfMiniMp3Debug
+        DfMiniMp3Debug.print("Notifications Queue Enlarged from ");
+        DfMiniMp3Debug.print(_length);
+        DfMiniMp3Debug.print(" to ");
+        DfMiniMp3Debug.println(newLength);
+#endif
+        if (newLength <= _length)
+        {
+            return;
+        }
+
+        // allocate new vector of items
+        T_ITEM* queueNew = new T_ITEM[newLength];
+        uint8_t backNew = 0;
+
+        // copy items from old queue vector
+        T_ITEM item;
+        while (Dequeue(&item))
+        {
+            queueNew[backNew++] = item;
+        }
+
+        // cleanup
+        delete[] _queue;
+        _queue = queueNew;
+        _length = newLength;
+        _front = 0;
+        _back = backNew;
+    }
+};


### PR DESCRIPTION
Notifications queued so not to disrupt the command/ack/error transaction.
Notifications called latter before a command transaction or during loop
Reply commands cleanup
Added software version query
Added constructor that takes RX/TX pins for ESP32 and others
GetPlaySources depricated due to conflict between data return and known Reply notification (they are the same with no context)
reset() will now wait until chip replies with online by default